### PR TITLE
Use `PowerCreateRequest` and add delay before allowing sleep again

### DIFF
--- a/Jellyfin.Plugin.PreventSleep/VanaraKernel32.cs
+++ b/Jellyfin.Plugin.PreventSleep/VanaraKernel32.cs
@@ -1,0 +1,212 @@
+﻿/*
+    MIT License
+
+    Copyright (c) 2017 David Hall
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+// https://github.com/dahall/Vanara/commit/153533f7e07bb78119dee90520ed5af6b5b584ae
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Jellyfin.Plugin.PreventSleep;
+
+public static class VanaraPInvokeKernel32
+{
+    public enum POWER_REQUEST_TYPE
+    {
+        PowerRequestDisplayRequired,
+        PowerRequestSystemRequired,
+        PowerRequestAwayModeRequired,
+        PowerRequestExecutionRequired,
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool PowerClearRequest(SafePowerRequestObject PowerRequest, POWER_REQUEST_TYPE RequestType);
+
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    public static extern SafePowerRequestObject PowerCreateRequest([In] REASON_CONTEXT Context);
+
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool PowerSetRequest(SafePowerRequestObject PowerRequest, POWER_REQUEST_TYPE RequestType);
+
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool CloseHandle(IntPtr hObject);
+
+    public class SafePowerRequestObject : SafeKernelHandle
+    {
+        public SafePowerRequestObject(IntPtr preexistingHandle, bool ownsHandle = true) : base(preexistingHandle, ownsHandle) { }
+
+        private SafePowerRequestObject() : base() { }
+    }
+
+    public enum DIAGNOSTIC_REASON : uint
+    {
+        DIAGNOSTIC_REASON_SIMPLE_STRING = 0x00000001,
+        DIAGNOSTIC_REASON_DETAILED_STRING = 0x00000002,
+        DIAGNOSTIC_REASON_NOT_SPECIFIED = 0x80000000
+    }
+
+    public enum DIAGNOSTIC_REASON_VERSION
+    {
+        DIAGNOSTIC_REASON_VERSION = 0
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public class REASON_CONTEXT : IDisposable
+    {
+        public DIAGNOSTIC_REASON_VERSION Version;
+        public DIAGNOSTIC_REASON Flags;
+        private DETAIL _reason;
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct DETAIL
+        {
+            public IntPtr LocalizedReasonModule;
+            public uint LocalizedReasonId;
+            public uint ReasonStringCount;
+            public IntPtr ReasonStrings;
+        }
+
+        public REASON_CONTEXT(string reason)
+        {
+            Version = DIAGNOSTIC_REASON_VERSION.DIAGNOSTIC_REASON_VERSION;
+            Flags = DIAGNOSTIC_REASON.DIAGNOSTIC_REASON_SIMPLE_STRING;
+            _reason.LocalizedReasonModule = Marshal.StringToHGlobalUni(reason);
+        }
+
+        void IDisposable.Dispose()
+        {
+            if (Flags == DIAGNOSTIC_REASON.DIAGNOSTIC_REASON_SIMPLE_STRING)
+                Marshal.FreeHGlobal(_reason.LocalizedReasonModule);
+        }
+    }
+
+    public abstract class SafeKernelHandle : SafeHANDLE, IKernelHandle
+    {
+        protected SafeKernelHandle() : base() { }
+
+        protected SafeKernelHandle(IntPtr preexistingHandle, bool ownsHandle = true) : base(preexistingHandle, ownsHandle) { }
+
+        protected override bool InternalReleaseHandle() => CloseHandle(handle);
+    }
+}
+
+public interface IHandle
+{
+    IntPtr DangerousGetHandle();
+}
+
+public interface IKernelHandle : IHandle { }
+
+[StructLayout(LayoutKind.Sequential), DebuggerDisplay("{handle}")]
+public struct HANDLE : IHandle
+{
+    private readonly IntPtr handle;
+
+    public HANDLE(IntPtr preexistingHandle) => handle = preexistingHandle;
+
+    public static HANDLE NULL => new(IntPtr.Zero);
+
+    public bool IsNull => handle == IntPtr.Zero;
+
+    public static explicit operator IntPtr(HANDLE h) => h.handle;
+
+    public static implicit operator HANDLE(IntPtr h) => new(h);
+
+    public static implicit operator HANDLE(SafeHandle h) => new(h.DangerousGetHandle());
+
+    public static bool operator !(HANDLE hMem) => hMem.IsNull;
+
+    public static bool operator !=(HANDLE h1, HANDLE h2) => !(h1 == h2);
+
+    public static bool operator ==(HANDLE h1, HANDLE h2) => h1.Equals(h2);
+
+    public override bool Equals(object obj) => obj is HANDLE h && handle == h.handle;
+
+    public override int GetHashCode() => handle.GetHashCode();
+
+    public IntPtr DangerousGetHandle() => handle;
+}
+
+[DebuggerDisplay("{handle}")]
+public abstract class SafeHANDLE : SafeHandleZeroOrMinusOneIsInvalid, IEquatable<SafeHANDLE>, IHandle
+{
+    public SafeHANDLE() : base(true)
+    {
+    }
+
+    protected SafeHANDLE(IntPtr preexistingHandle, bool ownsHandle = true) : base(ownsHandle) => SetHandle(preexistingHandle);
+
+    public bool IsNull => handle == IntPtr.Zero;
+
+    public static bool operator !(SafeHANDLE hMem) => hMem.IsInvalid;
+
+    public static bool operator !=(SafeHANDLE h1, IHandle h2) => !(h1 == h2);
+
+    public static bool operator !=(SafeHANDLE h1, IntPtr h2) => !(h1 == h2);
+
+    public static bool operator ==(SafeHANDLE h1, IHandle h2) => h1?.Equals(h2) ?? h2 is null;
+
+    public static bool operator ==(SafeHANDLE h1, IntPtr h2) => h1?.Equals(h2) ?? false;
+
+    public static implicit operator HANDLE(SafeHANDLE h) => h.handle;
+
+    public bool Equals(SafeHANDLE other) => ReferenceEquals(this, other) || other is not null && handle == other.handle && IsClosed == other.IsClosed;
+
+    public override bool Equals(object obj) => obj switch
+    {
+        IHandle ih => handle.Equals(ih.DangerousGetHandle()),
+        SafeHandle sh => handle.Equals(sh.DangerousGetHandle()),
+        IntPtr p => handle.Equals(p),
+        _ => base.Equals(obj),
+    };
+
+    public override int GetHashCode() => base.GetHashCode();
+
+    public IntPtr ReleaseOwnership()
+    {
+        var ret = handle;
+        SetHandleAsInvalid();
+        return ret;
+    }
+
+    protected abstract bool InternalReleaseHandle();
+
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+    protected override bool ReleaseHandle()
+    {
+        if (IsInvalid) return true;
+        if (!InternalReleaseHandle()) return false;
+        handle = IntPtr.Zero;
+        return true;
+    }
+
+    protected static T ThrowIfDisposed<T>(T h) where T : SafeHANDLE => h is null || h.IsInvalid ? throw new ObjectDisposedException(typeof(T).Name) : h;
+}


### PR DESCRIPTION
Hi,

Following on from your email, here's a PR with my changes.

* VanaraKernel32.cs is stripped down from the wonderful [Vanara](https://github.com/dahall/Vanara) P/Invoke library. Its DLLs add about 2/3 MBs' worth of dependencies, which I consider to be OTT for something where only a few functions from the WinAPI need to be called, hence my attempt to condense only the needed parts from it into one file. It seems trivial to write your own P/Invoke wrapper for `PowerCreateRequest` etc., but I was impressed with how easy it was to call said functions with Vanara in the first place and how it safely wraps the HANDLE returned

* I found I needed a delay before allowing sleep to occur again because, sometimes, Windows would put my computer to sleep as soon as `PowerClearRequest` was called so I would have to employ Wake-on-LAN so that I could play the next episode of something. I've hardcoded the relevant timer for unblocking (15 minutes after the last `SessionManager_PlaybackProgress` call) for micro-optimisation purposes (`SessionManager_PlaybackProgress` is called frequently) but, of course, that needs to be made configurable for a plugin to be used by all 

* In hindsight, the `__FUNCTION__` stuff seems overkill...

* I do not know if `MethodImplOptions.AggressiveOptimization` actually helps or, according to Stackoverflow, causes the JIT engine to produce less-optimised code than it would without it. I applied it to `SessionManager_PlaybackProgress` because of how frequently it's called but I have no idea if it's a help or a hindrance

* I can't see `PowerClearRequest` realistically failing, which is why I assume it always succeeds (there's not much you can do from the plugin's side if Windows won't allow it...) but it should probably be logged at least, I guess 

* The actual sleep blocking occurs in the `PlaybackProgress` callback because, as you noted, it's the only function guaranteed to be called. However, what I noticed when testing with the Findroid and official Jellyfin Android clients was that sometimes `SessionManager_PlaybackProgress` is called even for devices where the `PlaybackStopped` event has been received for them. I think this is a Jellyfin bug somewhere because I didn't always notice this happening after restarting the server.
As a result, I keep a list of removed devices, and do not allow for devices where the last reported activity has been greater than 30 seconds (also make configurable?) to delay unblocking sleep any further. While devices in `_removedDevices` are removed when `SessionManager_PlaybackStart` is called with a "reconnected" device, there may be a risk of, somehow, many devices accumulating in `_removedDevices` and not getting cleared, leading to ever-increasing RAM usage.
I have not checked if just checking `LastPlaybackCheckIn` is enough and `_removedDevices` can be removed entirely. With the cost of electricity, I prefer to err on the side of caution and make sure sleep can occur if it's very likely Jellyfin isn't serving media to any device.

* `HybridDictionary` is a good choice for `_removedDevices` for my personal use, but another Dictionary may be better for a generic plugin?

* Should `SessionManager_PlaybackProgress` be throttled? It's called *very frequently* and setting up another timer to delay calls to it by something like a second might be less taxing than having `_removedDevices` checked, a new DateTime instance created and the Interlocked variable checked nearly every second. On the other hand, maybe not...