### PR TITLE
Power requests, delay before reenabling sleep, further improvements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>0.0.1.0</Version>
-        <AssemblyVersion>0.0.1.0</AssemblyVersion>
-        <FileVersion>0.0.1.0</FileVersion>
+        <Version>0.1.0.0</Version>
+        <AssemblyVersion>0.1.0.0</AssemblyVersion>
+        <FileVersion>0.1.0.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Jellyfin.Plugin.PreventSleep/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.PreventSleep/Configuration/PluginConfiguration.cs
@@ -3,22 +3,6 @@ using MediaBrowser.Model.Plugins;
 namespace Jellyfin.Plugin.PreventSleep.Configuration;
 
 /// <summary>
-/// The configuration options.
-/// </summary>
-public enum SomeOptions
-{
-    /// <summary>
-    /// Option one.
-    /// </summary>
-    OneOption,
-
-    /// <summary>
-    /// Second option.
-    /// </summary>
-    AnotherOption
-}
-
-/// <summary>
 /// Plugin configuration.
 /// </summary>
 public class PluginConfiguration : BasePluginConfiguration
@@ -29,29 +13,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public PluginConfiguration()
     {
         // set default options here
-        Options = SomeOptions.AnotherOption;
-        TrueFalseSetting = true;
-        AnInteger = 2;
-        AString = "string";
+        UnblockSleepDelay = 1;
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether some true or false setting is enabled..
+    /// The amount of minutes to wait before re-enabling sleep.
     /// </summary>
-    public bool TrueFalseSetting { get; set; }
-
-    /// <summary>
-    /// Gets or sets an integer setting.
-    /// </summary>
-    public int AnInteger { get; set; }
-
-    /// <summary>
-    /// Gets or sets a string setting.
-    /// </summary>
-    public string AString { get; set; }
-
-    /// <summary>
-    /// Gets or sets an enum option.
-    /// </summary>
-    public SomeOptions Options { get; set; }
+    public int UnblockSleepDelay { get; set; }
 }

--- a/Jellyfin.Plugin.PreventSleep/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.PreventSleep/Configuration/PluginConfiguration.cs
@@ -17,7 +17,7 @@ public class PluginConfiguration : BasePluginConfiguration
     }
 
     /// <summary>
-    /// The amount of minutes to wait before re-enabling sleep.
+    /// Gets or sets the amount of minutes to wait before re-enabling sleep.
     /// </summary>
     public int UnblockSleepDelay { get; set; }
 }

--- a/Jellyfin.Plugin.PreventSleep/Configuration/configPage.html
+++ b/Jellyfin.Plugin.PreventSleep/Configuration/configPage.html
@@ -2,35 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Template</title>
+    <title>Prevent Sleep</title>
 </head>
 <body>
-    <div id="TemplateConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
+    <div id="PreventSleepConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
         <div data-role="content">
             <div class="content-primary">
-                <form id="TemplateConfigForm">
-                    <div class="selectContainer">
-                        <label class="selectLabel" for="Options">Several Options</label>
-                        <select is="emby-select" id="Options" name="Options" class="emby-select-withcolor emby-select">
-                            <option id="optOneOption" value="OneOption">One Option</option>
-                            <option id="optAnotherOption" value="AnotherOption">Another Option</option>
-                        </select>
-                    </div>
+                <form id="PreventSleepConfigForm">
                     <div class="inputContainer">
-                        <label class="inputLabel inputLabelUnfocused" for="AnInteger">An Integer</label>
-                        <input id="AnInteger" name="AnInteger" type="number" is="emby-input" min="0" />
-                        <div class="fieldDescription">A Description</div>
-                    </div>
-                    <div class="checkboxContainer checkboxContainer-withDescription">
-                        <label class="emby-checkbox-label">
-                            <input id="TrueFalseSetting" name="TrueFalseCheckBox" type="checkbox" is="emby-checkbox" />
-                            <span>A Checkbox</span>
-                        </label>
-                    </div>
-                    <div class="inputContainer">
-                        <label class="inputeLabel inputLabelUnfocused" for="AString">A String</label>
-                        <input id="AString" name="AString" type="text" is="emby-input" />
-                        <div class="fieldDescription">Another Description</div>
+                        <label class="inputLabel inputLabelUnfocused" for="UnblockSleepDelay">Delay before unblocking sleep (in minutes)</label>
+                        <input id="UnblockSleepDelay" name="UnblockSleepDelay" type="number" is="emby-input" min="1" />
+                        <div class="fieldDescription">Wait for the specified time after all playback has ended before allowing sleep again.</div>
                     </div>
                     <div>
                         <button is="emby-button" type="submit" class="raised button-submit block emby-button">
@@ -41,31 +23,25 @@
             </div>
         </div>
         <script type="text/javascript">
-            var TemplateConfig = {
+            var PreventSleepConfig = {
                 pluginUniqueId: 'd6b0196a-9885-4d87-b25c-562a57ebbe0b'
             };
 
-            document.querySelector('#TemplateConfigPage')
+            document.querySelector('#PreventSleepConfigPage')
                 .addEventListener('pageshow', function() {
                     Dashboard.showLoadingMsg();
-                    ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
-                        document.querySelector('#Options').value = config.Options;
-                        document.querySelector('#AnInteger').value = config.AnInteger;
-                        document.querySelector('#TrueFalseSetting').checked = config.TrueFalseSetting;
-                        document.querySelector('#AString').value = config.AString;
+                    ApiClient.getPluginConfiguration(PreventSleepConfig.pluginUniqueId).then(function (config) {
+                        document.querySelector('#UnblockSleepDelay').value = config.UnblockSleepDelay;
                         Dashboard.hideLoadingMsg();
                     });
                 });
 
-            document.querySelector('#TemplateConfigForm')
+            document.querySelector('#PreventSleepConfigForm')
                 .addEventListener('submit', function(e) {
                 Dashboard.showLoadingMsg();
-                ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
-                    config.Options = document.querySelector('#Options').value;
-                    config.AnInteger = document.querySelector('#AnInteger').value;
-                    config.TrueFalseSetting = document.querySelector('#TrueFalseSetting').checked;
-                    config.AString = document.querySelector('#AString').value;
-                    ApiClient.updatePluginConfiguration(TemplateConfig.pluginUniqueId, config).then(function (result) {
+                ApiClient.getPluginConfiguration(PreventSleepConfig.pluginUniqueId).then(function (config) {
+                    config.UnblockSleepDelay = document.querySelector('#UnblockSleepDelay').value;
+                    ApiClient.updatePluginConfiguration(PreventSleepConfig.pluginUniqueId, config).then(function (result) {
                         Dashboard.processPluginConfigurationUpdateResult(result);
                     });
                 });

--- a/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
+++ b/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
@@ -74,29 +74,15 @@ public class EventMonitorEntryPoint : IServerEntryPoint
 
     private void SessionManager_PlaybackStart(object? sender, PlaybackProgressEventArgs e)
     {
-        if (e.MediaInfo is null)
-        {
-            return;
-        }
-
-        if (e.Users.Count == 0)
-        {
-            return;
-        }
-
-        if (e.Item is not null && e.Item.IsThemeMedia)
-        {
-            return;
-        }
-
         var deviceId = e.DeviceId;
-        if (!_removedDevices.Contains(deviceId))
+        if ((e.MediaInfo is not null) &&
+            (e.Users.Count > 0) &&
+            (e.Item is null || !e.Item.IsThemeMedia) &&
+            _removedDevices.Contains(deviceId))
         {
-            return;
+            _removedDevices.Remove(deviceId);
+            _logger.LogDebug("Removed {DeviceId} from list of removed devices", deviceId);
         }
-
-        _removedDevices.Remove(deviceId);
-        _logger.LogDebug("Removed {DeviceId} from list of removed devices", deviceId);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]

--- a/Jellyfin.Plugin.PreventSleep/VanaraKernel32.cs
+++ b/Jellyfin.Plugin.PreventSleep/VanaraKernel32.cs
@@ -19,9 +19,8 @@
     https://github.com/dahall/Vanara/commit/153533f7e07bb78119dee90520ed5af6b5b584ae
 */
 
-#pragma warning disable CA1401 // PInvokesShouldNotBeVisible
-
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -53,18 +52,45 @@ public static class VanaraPInvokeKernel32
 
     [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool PowerClearRequest(SafePowerRequestObject powerRequest, POWER_REQUEST_TYPE requestType);
+    private static extern bool PowerClearRequest(SafePowerRequestObject powerRequest, POWER_REQUEST_TYPE requestType);
 
     [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
-    public static extern SafePowerRequestObject PowerCreateRequest([In] REASON_CONTEXT context);
-
-    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool PowerSetRequest(SafePowerRequestObject powerRequest, POWER_REQUEST_TYPE requestType);
+    private static extern SafePowerRequestObject PowerCreateRequest([In] REASON_CONTEXT context);
 
     [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool CloseHandle(IntPtr hObject);
+    private static extern bool PowerSetRequest(SafePowerRequestObject powerRequest, POWER_REQUEST_TYPE requestType);
+
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
+    public static void SafePowerClearRequest(SafePowerRequestObject powerRequest, POWER_REQUEST_TYPE requestType)
+    {
+        if (!PowerClearRequest(powerRequest, requestType))
+        {
+            throw new Win32Exception();
+        }
+    }
+
+    public static SafePowerRequestObject SafePowerCreateRequest(REASON_CONTEXT context)
+    {
+        var handle = PowerCreateRequest(context);
+        if (handle.IsInvalid)
+        {
+            throw new Win32Exception();
+        }
+
+        return handle;
+    }
+
+    public static void SafePowerSetRequest(SafePowerRequestObject powerRequest, POWER_REQUEST_TYPE requestType)
+    {
+        if (!PowerSetRequest(powerRequest, requestType))
+        {
+            throw new Win32Exception();
+        }
+    }
 
     public class SafePowerRequestObject : SafeKernelHandle
     {

--- a/Jellyfin.Plugin.PreventSleep/VanaraKernel32.cs
+++ b/Jellyfin.Plugin.PreventSleep/VanaraKernel32.cs
@@ -1,33 +1,29 @@
 ﻿/*
-    MIT License
+    Copyright (c) 2017 David Hall 2023 Faheem Pervez, Jonathan Schulz
 
-    Copyright (c) 2017 David Hall
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License.
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
 
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see<http://www.gnu.org/licenses/>.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE.
+
+    Originally published under MIT License, re-published with modifications
+    under GPLv3.
+    https://github.com/dahall/Vanara/commit/153533f7e07bb78119dee90520ed5af6b5b584ae
 */
 
-// https://github.com/dahall/Vanara/commit/153533f7e07bb78119dee90520ed5af6b5b584ae
+#pragma warning disable CA1401 // PInvokesShouldNotBeVisible
 
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
@@ -43,29 +39,6 @@ public static class VanaraPInvokeKernel32
         PowerRequestExecutionRequired,
     }
 
-    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool PowerClearRequest(SafePowerRequestObject PowerRequest, POWER_REQUEST_TYPE RequestType);
-
-    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
-    public static extern SafePowerRequestObject PowerCreateRequest([In] REASON_CONTEXT Context);
-
-    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool PowerSetRequest(SafePowerRequestObject PowerRequest, POWER_REQUEST_TYPE RequestType);
-
-    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
-    [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool CloseHandle(IntPtr hObject);
-
-    public class SafePowerRequestObject : SafeKernelHandle
-    {
-        public SafePowerRequestObject(IntPtr preexistingHandle, bool ownsHandle = true) : base(preexistingHandle, ownsHandle) { }
-
-        private SafePowerRequestObject() : base() { }
-    }
-
     public enum DIAGNOSTIC_REASON : uint
     {
         DIAGNOSTIC_REASON_SIMPLE_STRING = 0x00000001,
@@ -78,41 +51,77 @@ public static class VanaraPInvokeKernel32
         DIAGNOSTIC_REASON_VERSION = 0
     }
 
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool PowerClearRequest(SafePowerRequestObject powerRequest, POWER_REQUEST_TYPE requestType);
+
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    public static extern SafePowerRequestObject PowerCreateRequest([In] REASON_CONTEXT context);
+
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool PowerSetRequest(SafePowerRequestObject powerRequest, POWER_REQUEST_TYPE requestType);
+
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool CloseHandle(IntPtr hObject);
+
+    public class SafePowerRequestObject : SafeKernelHandle
+    {
+        public SafePowerRequestObject(IntPtr preexistingHandle, bool ownsHandle = true) : base(preexistingHandle, ownsHandle)
+        {
+        }
+
+        protected SafePowerRequestObject() : base()
+        {
+        }
+    }
+
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public class REASON_CONTEXT : IDisposable
     {
-        public DIAGNOSTIC_REASON_VERSION Version;
-        public DIAGNOSTIC_REASON Flags;
+        private readonly DIAGNOSTIC_REASON_VERSION _version;
+        private readonly DIAGNOSTIC_REASON _flags;
         private DETAIL _reason;
-
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        public struct DETAIL
-        {
-            public IntPtr LocalizedReasonModule;
-            public uint LocalizedReasonId;
-            public uint ReasonStringCount;
-            public IntPtr ReasonStrings;
-        }
 
         public REASON_CONTEXT(string reason)
         {
-            Version = DIAGNOSTIC_REASON_VERSION.DIAGNOSTIC_REASON_VERSION;
-            Flags = DIAGNOSTIC_REASON.DIAGNOSTIC_REASON_SIMPLE_STRING;
-            _reason.LocalizedReasonModule = Marshal.StringToHGlobalUni(reason);
+            _version = DIAGNOSTIC_REASON_VERSION.DIAGNOSTIC_REASON_VERSION;
+            _flags = DIAGNOSTIC_REASON.DIAGNOSTIC_REASON_SIMPLE_STRING;
+            _reason._localizedReasonModule = Marshal.StringToHGlobalUni(reason);
         }
 
         void IDisposable.Dispose()
         {
-            if (Flags == DIAGNOSTIC_REASON.DIAGNOSTIC_REASON_SIMPLE_STRING)
-                Marshal.FreeHGlobal(_reason.LocalizedReasonModule);
+            if (_flags == DIAGNOSTIC_REASON.DIAGNOSTIC_REASON_SIMPLE_STRING && _reason._localizedReasonModule != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(_reason._localizedReasonModule);
+                // explicitly set to zero to prevent double free errors
+                _reason._localizedReasonModule = IntPtr.Zero;
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct DETAIL
+        {
+            public IntPtr _localizedReasonModule;
+            public uint _localizedReasonId;
+            public uint _reasonStringCount;
+            public IntPtr _reasonStrings;
         }
     }
 
     public abstract class SafeKernelHandle : SafeHANDLE, IKernelHandle
     {
-        protected SafeKernelHandle() : base() { }
+        protected SafeKernelHandle() : base()
+        {
+        }
 
-        protected SafeKernelHandle(IntPtr preexistingHandle, bool ownsHandle = true) : base(preexistingHandle, ownsHandle) { }
+        protected SafeKernelHandle(IntPtr preexistingHandle, bool ownsHandle = true) : base(preexistingHandle, ownsHandle)
+        {
+        }
 
         protected override bool InternalReleaseHandle() => CloseHandle(handle);
     }
@@ -123,20 +132,23 @@ public interface IHandle
     IntPtr DangerousGetHandle();
 }
 
-public interface IKernelHandle : IHandle { }
-
-[StructLayout(LayoutKind.Sequential), DebuggerDisplay("{handle}")]
-public struct HANDLE : IHandle
+public interface IKernelHandle : IHandle
 {
-    private readonly IntPtr handle;
+}
 
-    public HANDLE(IntPtr preexistingHandle) => handle = preexistingHandle;
+[StructLayout(LayoutKind.Sequential)]
+[DebuggerDisplay("{handle}")]
+public readonly struct HANDLE : IHandle
+{
+    private readonly IntPtr _handle;
+
+    public HANDLE(IntPtr preexistingHandle) => _handle = preexistingHandle;
 
     public static HANDLE NULL => new(IntPtr.Zero);
 
-    public bool IsNull => handle == IntPtr.Zero;
+    public bool IsNull => _handle == IntPtr.Zero;
 
-    public static explicit operator IntPtr(HANDLE h) => h.handle;
+    public static explicit operator IntPtr(HANDLE h) => h._handle;
 
     public static implicit operator HANDLE(IntPtr h) => new(h);
 
@@ -148,11 +160,11 @@ public struct HANDLE : IHandle
 
     public static bool operator ==(HANDLE h1, HANDLE h2) => h1.Equals(h2);
 
-    public override bool Equals(object obj) => obj is HANDLE h && handle == h.handle;
+    public override bool Equals(object? obj) => obj is HANDLE h && _handle == h._handle;
 
-    public override int GetHashCode() => handle.GetHashCode();
+    public override int GetHashCode() => _handle.GetHashCode();
 
-    public IntPtr DangerousGetHandle() => handle;
+    public IntPtr DangerousGetHandle() => _handle;
 }
 
 [DebuggerDisplay("{handle}")]
@@ -166,6 +178,8 @@ public abstract class SafeHANDLE : SafeHandleZeroOrMinusOneIsInvalid, IEquatable
 
     public bool IsNull => handle == IntPtr.Zero;
 
+    public static implicit operator HANDLE(SafeHANDLE h) => h.handle;
+
     public static bool operator !(SafeHANDLE hMem) => hMem.IsInvalid;
 
     public static bool operator !=(SafeHANDLE h1, IHandle h2) => !(h1 == h2);
@@ -176,11 +190,10 @@ public abstract class SafeHANDLE : SafeHandleZeroOrMinusOneIsInvalid, IEquatable
 
     public static bool operator ==(SafeHANDLE h1, IntPtr h2) => h1?.Equals(h2) ?? false;
 
-    public static implicit operator HANDLE(SafeHANDLE h) => h.handle;
+    public bool Equals(SafeHANDLE? other) =>
+        ReferenceEquals(this, other) || (other is not null && handle == other.handle && IsClosed == other.IsClosed);
 
-    public bool Equals(SafeHANDLE other) => ReferenceEquals(this, other) || other is not null && handle == other.handle && IsClosed == other.IsClosed;
-
-    public override bool Equals(object obj) => obj switch
+    public override bool Equals(object? obj) => obj switch
     {
         IHandle ih => handle.Equals(ih.DangerousGetHandle()),
         SafeHandle sh => handle.Equals(sh.DangerousGetHandle()),
@@ -202,11 +215,21 @@ public abstract class SafeHANDLE : SafeHandleZeroOrMinusOneIsInvalid, IEquatable
     [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     protected override bool ReleaseHandle()
     {
-        if (IsInvalid) return true;
-        if (!InternalReleaseHandle()) return false;
+        if (IsInvalid)
+        {
+            return true;
+        }
+
+        if (!InternalReleaseHandle())
+        {
+            return false;
+        }
+
         handle = IntPtr.Zero;
         return true;
     }
 
-    protected static T ThrowIfDisposed<T>(T h) where T : SafeHANDLE => h is null || h.IsInvalid ? throw new ObjectDisposedException(typeof(T).Name) : h;
+    protected static T ThrowIfDisposed<T>(T h)
+        where T : SafeHANDLE
+        => h is null || h.IsInvalid ? throw new ObjectDisposedException(typeof(T).Name) : h;
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Prevent Sleep Plugin for Jellyfin (WIP)
+# Prevent Sleep Plugin for Jellyfin
 
 ## About
 
@@ -14,7 +14,7 @@ To build this plugin, follow e.g. [these steps](https://github.com/jellyfin/jell
 
 ## Known issues
 - As of now, only Windows is supported for the OS of the server.
-- This plugin may not work if the server is capable of connected standby, see https://superuser.com/a/1287544.
+- This plugin might not work correctly if the server is capable of connected standby, see https://superuser.com/a/1287544. Testing would be greatly appreciated.
 
 Please don't hesistate to report issues if you find any.
 


### PR DESCRIPTION
A number of new features have been contributed by @qwerty12 in #1. As noted in that pull request, here are some things to check before merging:
- ~Write our own wrapper for PowerRequests if its isn't too much work~
   Update: As it is right now, the library adds hardly any overhead at all (I measured 5KB in a test file). It looks reliable, I will only get rid of some linter issues and work out license stuff if needed (Vanara P/Invoke is MIT licensed).
- See if there is an easier solution to the Android app issue - I will also try to reproduce it
- Possible throttling of `SessionManager_PlaybackProgress`, this is something I noticed as well