### PR TITLE
Allow for the sleep unblock delay to be configured

### DIFF
--- a/Jellyfin.Plugin.PreventSleep/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.PreventSleep/Configuration/PluginConfiguration.cs
@@ -17,7 +17,7 @@ public class PluginConfiguration : BasePluginConfiguration
     }
 
     /// <summary>
-    /// The amount of milliseconds to wait before re-enabling sleep.
+    /// Gets or sets the amount of milliseconds to wait before re-enabling sleep.
     /// </summary>
     public int UnblockSleepDelay { get; set; }
 }

--- a/Jellyfin.Plugin.PreventSleep/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.PreventSleep/Configuration/PluginConfiguration.cs
@@ -3,22 +3,6 @@ using MediaBrowser.Model.Plugins;
 namespace Jellyfin.Plugin.PreventSleep.Configuration;
 
 /// <summary>
-/// The configuration options.
-/// </summary>
-public enum SomeOptions
-{
-    /// <summary>
-    /// Option one.
-    /// </summary>
-    OneOption,
-
-    /// <summary>
-    /// Second option.
-    /// </summary>
-    AnotherOption
-}
-
-/// <summary>
 /// Plugin configuration.
 /// </summary>
 public class PluginConfiguration : BasePluginConfiguration
@@ -29,29 +13,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public PluginConfiguration()
     {
         // set default options here
-        Options = SomeOptions.AnotherOption;
-        TrueFalseSetting = true;
-        AnInteger = 2;
-        AString = "string";
+        UnblockSleepDelay = 60000;
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether some true or false setting is enabled..
+    /// The amount of milliseconds to wait before re-enabling sleep.
     /// </summary>
-    public bool TrueFalseSetting { get; set; }
-
-    /// <summary>
-    /// Gets or sets an integer setting.
-    /// </summary>
-    public int AnInteger { get; set; }
-
-    /// <summary>
-    /// Gets or sets a string setting.
-    /// </summary>
-    public string AString { get; set; }
-
-    /// <summary>
-    /// Gets or sets an enum option.
-    /// </summary>
-    public SomeOptions Options { get; set; }
+    public int UnblockSleepDelay { get; set; }
 }

--- a/Jellyfin.Plugin.PreventSleep/Configuration/configPage.html
+++ b/Jellyfin.Plugin.PreventSleep/Configuration/configPage.html
@@ -2,35 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Template</title>
+    <title>Prevent Sleep</title>
 </head>
 <body>
-    <div id="TemplateConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
+    <div id="PreventSleepConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
         <div data-role="content">
             <div class="content-primary">
-                <form id="TemplateConfigForm">
-                    <div class="selectContainer">
-                        <label class="selectLabel" for="Options">Several Options</label>
-                        <select is="emby-select" id="Options" name="Options" class="emby-select-withcolor emby-select">
-                            <option id="optOneOption" value="OneOption">One Option</option>
-                            <option id="optAnotherOption" value="AnotherOption">Another Option</option>
-                        </select>
-                    </div>
+                <form id="PreventSleepConfigForm">
                     <div class="inputContainer">
-                        <label class="inputLabel inputLabelUnfocused" for="AnInteger">An Integer</label>
-                        <input id="AnInteger" name="AnInteger" type="number" is="emby-input" min="0" />
-                        <div class="fieldDescription">A Description</div>
-                    </div>
-                    <div class="checkboxContainer checkboxContainer-withDescription">
-                        <label class="emby-checkbox-label">
-                            <input id="TrueFalseSetting" name="TrueFalseCheckBox" type="checkbox" is="emby-checkbox" />
-                            <span>A Checkbox</span>
-                        </label>
-                    </div>
-                    <div class="inputContainer">
-                        <label class="inputeLabel inputLabelUnfocused" for="AString">A String</label>
-                        <input id="AString" name="AString" type="text" is="emby-input" />
-                        <div class="fieldDescription">Another Description</div>
+                        <label class="inputLabel inputLabelUnfocused" for="UnblockSleepDelay">Delay before unblocking sleep (in minutes)</label>
+                        <input id="UnblockSleepDelay" name="UnblockSleepDelay" type="number" is="emby-input" min="1" max="60" />
+                        <div class="fieldDescription">Wait for the specified time after all playback has ended before allowing sleep again.</div>
                     </div>
                     <div>
                         <button is="emby-button" type="submit" class="raised button-submit block emby-button">
@@ -41,31 +23,25 @@
             </div>
         </div>
         <script type="text/javascript">
-            var TemplateConfig = {
+            var PreventSleepConfig = {
                 pluginUniqueId: 'd6b0196a-9885-4d87-b25c-562a57ebbe0b'
             };
 
-            document.querySelector('#TemplateConfigPage')
+            document.querySelector('#PreventSleepConfigPage')
                 .addEventListener('pageshow', function() {
                     Dashboard.showLoadingMsg();
-                    ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
-                        document.querySelector('#Options').value = config.Options;
-                        document.querySelector('#AnInteger').value = config.AnInteger;
-                        document.querySelector('#TrueFalseSetting').checked = config.TrueFalseSetting;
-                        document.querySelector('#AString').value = config.AString;
+                    ApiClient.getPluginConfiguration(PreventSleepConfig.pluginUniqueId).then(function (config) {
+                        document.querySelector('#UnblockSleepDelay').value = Math.floor(config.UnblockSleepDelay / 60000);
                         Dashboard.hideLoadingMsg();
                     });
                 });
 
-            document.querySelector('#TemplateConfigForm')
+            document.querySelector('#PreventSleepConfigForm')
                 .addEventListener('submit', function(e) {
                 Dashboard.showLoadingMsg();
-                ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
-                    config.Options = document.querySelector('#Options').value;
-                    config.AnInteger = document.querySelector('#AnInteger').value;
-                    config.TrueFalseSetting = document.querySelector('#TrueFalseSetting').checked;
-                    config.AString = document.querySelector('#AString').value;
-                    ApiClient.updatePluginConfiguration(TemplateConfig.pluginUniqueId, config).then(function (result) {
+                ApiClient.getPluginConfiguration(PreventSleepConfig.pluginUniqueId).then(function (config) {
+                    config.UnblockSleepDelay = document.querySelector('#UnblockSleepDelay').value * 60000;
+                    ApiClient.updatePluginConfiguration(PreventSleepConfig.pluginUniqueId, config).then(function (result) {
                         Dashboard.processPluginConfigurationUpdateResult(result);
                     });
                 });


### PR DESCRIPTION
This adds a setting to allow the amount of minutes the plugin will wait before allowing sleep again to be changed, replacing the hardcoded default of 15 minutes.

![image](https://user-images.githubusercontent.com/309008/236195210-e5afdbd5-5a9a-49c7-a31e-4a883d8eb7d9.png)

The default is a minute. It's also the minimum allowed value, because a timer of some sort needs to be in place to call `PowerClearRequest`.

This also won't apply changes to the setting retroactively in all cases. For example, if the unblock delay is initially set to a high value (say, 30 minutes), all playback is stopped, the setting gets reduced to a minute by the user, then `PowerClearRequest` will still be called ~30 minutes later because there's no calls being made to `PlaybackProgress` by Jellyfin. As it currently stands, having only `PlaybackProgress` manipulate the timer does make things simple, so I'm not really inclined to look into it.

If you can come up with better variable names and wording for the setting, then please change away.

---

I have also changed the way the timer is created. It's now instantiated in advance, so that the null check can be removed from the `PlaybackProgress` callback.