### PR TITLE
Small changes

### DIFF
--- a/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
+++ b/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
@@ -63,14 +63,12 @@ public class EventMonitorEntryPoint : IServerEntryPoint
 
     public Task RunAsync()
     {
-        if (_powerRequest is null)
+        if (_powerRequest is not null)
         {
-            return Task.CompletedTask;
+            ApplySettingsFromConfig();
+            _sessionManager.PlaybackProgress += SessionManager_PlaybackProgress;
+            Plugin.Instance!.ConfigurationChanged += Plugin_ConfigurationChanged;
         }
-
-        ApplySettingsFromConfig();
-        _sessionManager.PlaybackProgress += SessionManager_PlaybackProgress;
-        Plugin.Instance!.ConfigurationChanged += Plugin_ConfigurationChanged;
 
         return Task.CompletedTask;
     }


### PR DESCRIPTION
* Check to see if the debug loglevel is enabled. To avoid peppering the code with copious amounts of `if (_isDebugLogEnabled)`, I only add it to the "Time since last checkin" since it's called (kind of relatively) often. The JIT engine should be able to optimise out the `LogDebug` call since `_isDebugLogEnabled` won't change. For that matter, `_isDebugLogEnabled` is only set at the time of construction, because, as far as I know, Jellyfin doesn't offer a way to change plugins' loglevels at runtime - you edit logging.json and restart the server

* Return early in `RunAsync()`  if, for whatever reason, `_powerRequest` couldn't be created in the constructor and is null. This stops listening for events that will ultimately yield nothing in that case

* I find the "Attempting to block sleep" and "Calling PowerClearRequest: unblocking sleep" messages to be redundant with other changes. I originally had them in because they were getting logged before the lock - as it currently stands, you always know if `PowerCreateRequest` and `PowerClearRequest` are called, because either the success message is printed, a message saying why they failed or a standard exception log for any exception other than a Win32 one

* Various other small changes