### PR TITLE
Support installation via custom repository via manifest

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "name": "Launch",
             "request": "launch",
             "preLaunchTask": "build-and-copy",
-            "program": "${config:jellyfinDir}/bin/Debug/net9.0/jellyfin.dll",
+            "program": "${config:jellyfinDir}/bin/Debug/net8.0/jellyfin.dll",
             "args": [
                //"--nowebclient"
                "--webdir",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -48,7 +48,7 @@
         "type": "shell",
         "command": "cp",
         "args": [
-           "./${config:pluginName}/bin/Debug/net9.0/publish/${config:pluginName}.dll",
+           "./${config:pluginName}/bin/Debug/net8.0/publish/${config:pluginName}.dll",
            "${config:jellyfinDataDir}/plugins/${config:pluginName}/"
         ]
     },

--- a/Jellyfin.Plugin.PreventSleep/Jellyfin.Plugin.PreventSleep.csproj
+++ b/Jellyfin.Plugin.PreventSleep/Jellyfin.Plugin.PreventSleep.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.PreventSleep</RootNamespace>
     <!-- <GenerateDocumentationFile>true</GenerateDocumentationFile> -->
     <!-- <TreatWarningsAsErrors>true</TreatWarningsAsErrors> -->

--- a/build.yaml
+++ b/build.yaml
@@ -2,10 +2,10 @@
 name: "Prevent Sleep"
 guid: "d6b0196a-9885-4d87-b25c-562a57ebbe0b"
 version: "0.2.0.0"
-targetAbi: "10.11.0.0"
-framework: "net9.0"
+targetAbi: "10.9.0.0"
+framework: "net8.0"
 overview: "Prevent system sleep when streaming"
-description: "Prevents the system from entering sleep mode when there are active streams."
+description: "Prevent the system from entering sleep mode when there are active streams. Support is limited to servers running Windows."
 category: "General"
 owner: "jellyfin"
 artifacts:


### PR DESCRIPTION
This PR avoids the need for manual installation and allows installation by adding a new custom repository in the plugins configuration.

<img width="1663" height="331" alt="image" src="https://github.com/user-attachments/assets/bc0e176a-fc22-48cf-ab79-3ca6ff59c052" />

By adding this repo's new manifest.json it will allow installation from repo.
This also fixes the error that arises in jellyfin 10.11.x (see https://github.com/jonschz/jellyfin-plugin-preventsleep/issues/11)

Result by testing with a fake release on my fork:

<img width="2362" height="1024" alt="image" src="https://github.com/user-attachments/assets/74c4081d-283e-47df-bcea-a9b384de11e5" />

@jonschz 
A few changes are first required from your side before this can be merged.
You'll need to upload a zip file with the following name convention (`Prevent Sleep_<version>` -> f.e. `Prevent Sleep_0.2.0.0` in case you would re-use existing version) in the release instead of the plain dll file.
The zip file name will be used as folder name for installation (cfr other plugins names)
<img width="1032" height="337" alt="image" src="https://github.com/user-attachments/assets/cc614d93-c3b8-4477-9783-25b063740b7b" />


Then you'll need to generate the md5 checksum from this zip file and add it in the `manifest.json`.
Also the timestamp needs to be updated to the timestamp of the zip file.

I've also created a separate PR for jellyfin 10.11.x support. https://github.com/jonschz/jellyfin-plugin-preventsleep/pull/13
Maybe it's easier to merge this one first and then do the necessary for a new version as mentioned above.
I can assist when needed (once you have the zip ready with the dll, we prepare the manifest)

