### PR TITLE
Close power request object by disposing

### DIFF
--- a/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
+++ b/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
@@ -204,6 +204,7 @@ public class EventMonitorEntryPoint(ISessionManager sessionManager, ILoggerFacto
                 }
             }
 
+            (_powerManagement as IDisposable)?.Dispose();
             _powerManagement = null;
 
             _unblockTimer?.Dispose();

--- a/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
+++ b/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
@@ -204,7 +204,7 @@ public class EventMonitorEntryPoint(ISessionManager sessionManager, ILoggerFacto
                 }
             }
 
-            (_powerManagement as IDisposable)?.Dispose();
+            _powerManagement?.Dispose();
             _powerManagement = null;
 
             _unblockTimer?.Dispose();

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/WindowsPowerManagement.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/WindowsPowerManagement.cs
@@ -8,7 +8,7 @@ using Windows.Win32;
 
 namespace Jellyfin.Plugin.PreventSleep.Infrastructure;
 
-public sealed class WindowsPowerManagement : IPowerManagement
+public sealed class WindowsPowerManagement : IPowerManagement, IDisposable
 {
     private const string JellyfinPowerSchemeName = "Temporary Jellyfin PreventSleep Scheme";
     private const string JellyfinPowerSchemeDescription = "Temporary power scheme created by jellyfin-plugin-preventsleep to prevent unexpected shutdowns. Will be deleted automatically when no longer used.";
@@ -163,5 +163,10 @@ public sealed class WindowsPowerManagement : IPowerManagement
         }
 
         _windowsPowerApi.PowerClearSystemRequiredRequest(_powerRequest);
+    }
+
+    public void Dispose()
+    {
+        _powerRequest.Dispose();
     }
 }

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/WindowsPowerManagement.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/WindowsPowerManagement.cs
@@ -8,7 +8,7 @@ using Windows.Win32;
 
 namespace Jellyfin.Plugin.PreventSleep.Infrastructure;
 
-public sealed class WindowsPowerManagement : IPowerManagement, IDisposable
+public sealed class WindowsPowerManagement : IPowerManagement
 {
     private const string JellyfinPowerSchemeName = "Temporary Jellyfin PreventSleep Scheme";
     private const string JellyfinPowerSchemeDescription = "Temporary power scheme created by jellyfin-plugin-preventsleep to prevent unexpected shutdowns. Will be deleted automatically when no longer used.";
@@ -165,6 +165,7 @@ public sealed class WindowsPowerManagement : IPowerManagement, IDisposable
         _windowsPowerApi.PowerClearSystemRequiredRequest(_powerRequest);
     }
 
+    /// <inheritdoc />
     public void Dispose()
     {
         _powerRequest.Dispose();

--- a/Jellyfin.Plugin.PreventSleep/Interface/IPowerManagement.cs
+++ b/Jellyfin.Plugin.PreventSleep/Interface/IPowerManagement.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace Jellyfin.Plugin.PreventSleep.Interface;
 
-public interface IPowerManagement
+public interface IPowerManagement : IDisposable
 {
     public void BlockSleep();
 


### PR DESCRIPTION
Tries to dispose the `SafeFileHandle` from `PowerCreateRequest` during plugin shutdown to ensure the underlying handle is released ASAP