### PR TITLE
Add Linux inhibition support via logind

### DIFF
--- a/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
+++ b/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
@@ -119,6 +119,12 @@ public class EventMonitorEntryPoint(ISessionManager sessionManager, ILoggerFacto
             {
                 _logger.LogError(e, "Failed to block sleep: {Error}", e);
             }
+            catch (Exception e) when (e is LinuxDbusException or UnauthorizedAccessException)
+            {
+                _logger.LogError(e, "Failed to block sleep: {Error}", e);
+                _powerManagement.Dispose();
+                _powerManagement = null; // stop log spam
+            }
         }
     }
 
@@ -133,6 +139,19 @@ public class EventMonitorEntryPoint(ISessionManager sessionManager, ILoggerFacto
                 return new WindowsPowerManagement(_loggerFactory, Plugin.Instance!);
             }
             catch (Win32Exception e)
+            {
+                _logger.LogError(e, "Failed to set up power management. Preventing sleep will not work: {Error}", e);
+                return null;
+            }
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            try
+            {
+                return new LinuxLogindPowerManagement();
+            }
+            catch (Exception e) when (e is DllNotFoundException or LinuxDbusException)
             {
                 _logger.LogError(e, "Failed to set up power management. Preventing sleep will not work: {Error}", e);
                 return null;

--- a/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
+++ b/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
@@ -15,7 +15,6 @@ along with this program. If not, see<http://www.gnu.org/licenses/>.
 */
 
 using System;
-using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -115,13 +114,9 @@ public class EventMonitorEntryPoint(ISessionManager sessionManager, ILoggerFacto
                 _powerManagement.BlockSleep();
                 _unblockTimer = new Timer(UnblockSleepTimerCallback, null, TimerInterval, TimerInterval);
             }
-            catch (Win32Exception e)
+            catch (Exception e)
             {
-                _logger.LogError(e, "Failed to block sleep: {Error}", e);
-            }
-            catch (Exception e) when (e is LinuxDbusException or UnauthorizedAccessException)
-            {
-                _logger.LogError(e, "Failed to block sleep: {Error}", e);
+                _logger.LogError(e, "Failed to block sleep, will not retry until Jellyfin is restarted: {Error}", e);
                 _powerManagement.Dispose();
                 _powerManagement = null; // stop log spam
             }
@@ -132,35 +127,27 @@ public class EventMonitorEntryPoint(ISessionManager sessionManager, ILoggerFacto
     private IPowerManagement? CreatePowerManagement()
 #pragma warning restore CA1859
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        try
         {
-            try
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return new WindowsPowerManagement(_loggerFactory, Plugin.Instance!);
             }
-            catch (Win32Exception e)
-            {
-                _logger.LogError(e, "Failed to set up power management. Preventing sleep will not work: {Error}", e);
-                return null;
-            }
-        }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            try
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 return new LinuxLogindPowerManagement(_loggerFactory);
             }
-            catch (Exception e) when (e is DllNotFoundException or LinuxDbusException)
-            {
-                _logger.LogError(e, "Failed to set up power management. Preventing sleep will not work: {Error}", e);
-                return null;
-            }
+
+            _logger.LogError("Platform is not supported: {Platform}", RuntimeInformation.OSDescription);
+
+            return null;
         }
-
-        _logger.LogError("Platform is not supported: {Platform}", RuntimeInformation.OSDescription);
-
-        return null;
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to set up power management. Preventing sleep will not work: {Error}", e);
+            return null;
+        }
     }
 
     // Periodically check if the PowerRequest can be cleared.
@@ -193,7 +180,7 @@ public class EventMonitorEntryPoint(ISessionManager sessionManager, ILoggerFacto
             {
                 _powerManagement.UnblockSleep();
             }
-            catch (Win32Exception e)
+            catch (Exception e)
             {
                 _logger.LogError(e, "Failed to unblock sleep: {Error}", e);
             }
@@ -217,7 +204,7 @@ public class EventMonitorEntryPoint(ISessionManager sessionManager, ILoggerFacto
                     // Important because it may have to clean up power schemes.
                     _powerManagement?.UnblockSleep();
                 }
-                catch (Win32Exception e)
+                catch (Exception e)
                 {
                     _logger.LogError(e, "Failed to unblock sleep during teardown: {Error}", e);
                 }

--- a/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
+++ b/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
@@ -149,7 +149,7 @@ public class EventMonitorEntryPoint(ISessionManager sessionManager, ILoggerFacto
         {
             try
             {
-                return new LinuxLogindPowerManagement();
+                return new LinuxLogindPowerManagement(_loggerFactory);
             }
             catch (Exception e) when (e is DllNotFoundException or LinuxDbusException)
             {

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxDbusApi.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxDbusApi.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -20,7 +19,7 @@ internal static partial class LinuxDbusApi
 
     internal static void MakeThreadSafe()
     {
-        if (Interlocked.Exchange(ref _initialised, 1) == 0)
+        if (Interlocked.Exchange(ref _threadsInitialised, 1) == 0)
         {
             if (!dbus_threads_init_default())
             {

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxDbusApi.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxDbusApi.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.Win32.SafeHandles;
+
+namespace Jellyfin.Plugin.PreventSleep.Infrastructure;
+
+internal static partial class LinuxDbusApi
+{
+    private const string LibDbus = "libdbus-1.so.3";
+    private static int _initialised;
+
+    internal const int DbusBusSystem = 1;
+    internal const int DbusTypeString = 's';
+    internal const int DbusTypeUnixFd = 'h';
+
+    internal const string DbusErrorInteractiveAuthorizationRequired =
+        "org.freedesktop.DBus.Error.InteractiveAuthorizationRequired";
+
+    internal static void MakeThreadSafe()
+    {
+        if (Interlocked.Exchange(ref _initialised, 1) == 0)
+        {
+            if (!dbus_threads_init_default())
+            {
+                throw new LinuxDbusException("Could not initialise D-BUS thread support (OOM?)");
+            }
+        }
+    }
+
+    internal static SafeFileHandle MessageIterGetFileDescriptor(ref DBusMessageIter iter)
+    {
+        // "Unix file descriptors that are read with this function will have the FD_CLOEXEC flag set."
+        dbus_message_iter_get_basic(ref iter, out var fd);
+        return new SafeFileHandle(fd, ownsHandle: true);
+    }
+
+#pragma warning disable SA1300
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial nint dbus_bus_get_private(int busType, ref DBusError error);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void dbus_connection_close(nint connection);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial nint dbus_connection_send_with_reply_and_block(
+        nint connection, nint message, int timeoutMs, ref DBusError error);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void dbus_connection_set_exit_on_disconnect(
+        nint connection,
+        [MarshalAs(UnmanagedType.U4)] bool exitOnDisconnect);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void dbus_connection_unref(nint connection);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void dbus_error_free(ref DBusError error);
+
+    [LibraryImport(LibDbus, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    [return: MarshalAs(UnmanagedType.U4)]
+    internal static partial bool dbus_error_has_name(in DBusError error, string name);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void dbus_error_init(out DBusError error);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    [return: MarshalAs(UnmanagedType.U4)]
+    internal static partial bool dbus_error_is_set(in DBusError error);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    [return: MarshalAs(UnmanagedType.U4)]
+    internal static partial bool dbus_message_iter_append_basic(
+        ref DBusMessageIter iter, int type, nint value);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    [return: MarshalAs(UnmanagedType.U4)]
+    internal static partial bool dbus_message_iter_append_basic(
+        ref DBusMessageIter iter, int type,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] in string value);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int dbus_message_iter_get_arg_type(
+        in DBusMessageIter iter);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void dbus_message_iter_get_basic(
+        ref DBusMessageIter iter, nint value);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void dbus_message_iter_get_basic(
+        ref DBusMessageIter iter, out int value);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    [return: MarshalAs(UnmanagedType.U4)]
+    internal static partial bool dbus_message_iter_init(
+        nint message, out DBusMessageIter iter);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void dbus_message_iter_init_append(
+        nint message, out DBusMessageIter iter);
+
+    [LibraryImport(LibDbus, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial nint dbus_message_new_method_call(
+        string busName, string path, string iface, string method);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void dbus_message_unref(nint message);
+
+    [LibraryImport(LibDbus)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    [return: MarshalAs(UnmanagedType.U4)]
+    private static partial bool dbus_threads_init_default();
+#pragma warning restore SA1300
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DBusError
+    {
+        private nint _name;
+        internal nint Message;
+        private uint _flags;
+        private nint _padding2;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 128)]
+    internal struct DBusMessageIter;
+}

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxDbusApi.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxDbusApi.cs
@@ -97,12 +97,7 @@ internal static partial class LinuxDbusApi
 
     [LibraryImport(LibDbus)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial void dbus_message_iter_get_basic(
-        ref DBusMessageIter iter, nint value);
-
-    [LibraryImport(LibDbus)]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial void dbus_message_iter_get_basic(
+    private static partial void dbus_message_iter_get_basic(
         ref DBusMessageIter iter, out int value);
 
     [LibraryImport(LibDbus)]

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxDbusApi.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxDbusApi.cs
@@ -9,7 +9,7 @@ namespace Jellyfin.Plugin.PreventSleep.Infrastructure;
 internal static partial class LinuxDbusApi
 {
     private const string LibDbus = "libdbus-1.so.3";
-    private static int _initialised;
+    private static int _threadsInitialised;
 
     internal const int DbusBusSystem = 1;
     internal const int DbusTypeString = 's';

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxDbusException.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxDbusException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Jellyfin.Plugin.PreventSleep.Infrastructure;
+
+internal sealed class LinuxDbusException(string message) : Exception(message)
+{
+    internal LinuxDbusException(string message, in LinuxDbusApi.DBusError error)
+        : this(
+            LinuxDbusApi.dbus_error_is_set(error) &&
+            Marshal.PtrToStringUTF8(error.Message) is { } reason
+                ? $"{message}: {reason}"
+                : message)
+    {
+    }
+}

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxLogindPowerManagement.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxLogindPowerManagement.cs
@@ -1,15 +1,18 @@
 using System;
 using Jellyfin.Plugin.PreventSleep.Interface;
+using Microsoft.Extensions.Logging;
 using Microsoft.Win32.SafeHandles;
 
 namespace Jellyfin.Plugin.PreventSleep.Infrastructure;
 
 internal sealed class LinuxLogindPowerManagement : IPowerManagement
 {
+    private readonly ILogger<LinuxLogindPowerManagement> _logger;
     private SafeFileHandle? _inhibitorHandle;
 
-    public LinuxLogindPowerManagement()
+    public LinuxLogindPowerManagement(ILoggerFactory loggerFactory)
     {
+        _logger = loggerFactory.CreateLogger<LinuxLogindPowerManagement>();
         LinuxDbusApi.MakeThreadSafe();
     }
 
@@ -83,6 +86,7 @@ internal sealed class LinuxLogindPowerManagement : IPowerManagement
             }
 
             _inhibitorHandle = LinuxDbusApi.MessageIterGetFileDescriptor(ref replyIter);
+            _logger.LogDebug("org.freedesktop.login1.Manager.Inhibit succeeded: sleep blocked");
         }
         finally
         {
@@ -111,8 +115,12 @@ internal sealed class LinuxLogindPowerManagement : IPowerManagement
 
     public void UnblockSleep()
     {
-        _inhibitorHandle?.Close();
-        _inhibitorHandle = null;
+        if (_inhibitorHandle is not null)
+        {
+            _inhibitorHandle.Close();
+            _inhibitorHandle = null;
+            _logger.LogDebug("Inhibitor file descriptor closed: sleep re-enabled");
+        }
     }
 
     public void Dispose()

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxLogindPowerManagement.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/LinuxLogindPowerManagement.cs
@@ -1,0 +1,122 @@
+using System;
+using Jellyfin.Plugin.PreventSleep.Interface;
+using Microsoft.Win32.SafeHandles;
+
+namespace Jellyfin.Plugin.PreventSleep.Infrastructure;
+
+internal sealed class LinuxLogindPowerManagement : IPowerManagement
+{
+    private SafeFileHandle? _inhibitorHandle;
+
+    public LinuxLogindPowerManagement()
+    {
+        LinuxDbusApi.MakeThreadSafe();
+    }
+
+    public void BlockSleep()
+    {
+        const string What = "sleep";
+        const string Who = "Prevent Sleep Plugin for Jellyfin";
+        const string Why = "Serving files/waiting for the configured amount of time for further requests";
+        const string Mode = "block";
+
+        var conn = nint.Zero;
+        var msg = nint.Zero;
+        var reply = nint.Zero;
+
+        if (_inhibitorHandle is not null)
+        {
+            return;
+        }
+
+        LinuxDbusApi.dbus_error_init(out var error);
+        try
+        {
+            conn = LinuxDbusApi.dbus_bus_get_private(LinuxDbusApi.DbusBusSystem, ref error);
+            if (conn == nint.Zero)
+            {
+                throw new LinuxDbusException("Could not connect to system bus", in error);
+            }
+
+            LinuxDbusApi.dbus_connection_set_exit_on_disconnect(conn, false);
+
+            msg = LinuxDbusApi.dbus_message_new_method_call(
+                "org.freedesktop.login1",
+                "/org/freedesktop/login1",
+                "org.freedesktop.login1.Manager",
+                "Inhibit");
+            if (msg == nint.Zero)
+            {
+                throw new LinuxDbusException("Could not construct message (OOM?)");
+            }
+
+            LinuxDbusApi.dbus_message_iter_init_append(msg, out var appendIter);
+            if (!LinuxDbusApi.dbus_message_iter_append_basic(ref appendIter, LinuxDbusApi.DbusTypeString, What) ||
+                !LinuxDbusApi.dbus_message_iter_append_basic(ref appendIter, LinuxDbusApi.DbusTypeString, Who) ||
+                !LinuxDbusApi.dbus_message_iter_append_basic(ref appendIter, LinuxDbusApi.DbusTypeString, Why) ||
+                !LinuxDbusApi.dbus_message_iter_append_basic(ref appendIter, LinuxDbusApi.DbusTypeString, Mode))
+            {
+                throw new LinuxDbusException("Could not append args to message (OOM?)");
+            }
+
+            reply = LinuxDbusApi.dbus_connection_send_with_reply_and_block(conn, msg, -1, ref error);
+            if (reply == nint.Zero)
+            {
+                if (LinuxDbusApi.dbus_error_has_name(
+                        in error, LinuxDbusApi.DbusErrorInteractiveAuthorizationRequired))
+                {
+                    throw new UnauthorizedAccessException(
+                        "Preventing sleep requires authentication. See https://github.com/jonschz/jellyfin-plugin-preventsleep/blob/main/docs/Linux.md");
+                }
+
+                throw new LinuxDbusException("Could not request inhibition", in error);
+            }
+
+            if (!LinuxDbusApi.dbus_message_iter_init(reply, out var replyIter))
+            {
+                throw new LinuxDbusException("Could not read arguments from reply");
+            }
+
+            if (LinuxDbusApi.dbus_message_iter_get_arg_type(in replyIter) is not LinuxDbusApi.DbusTypeUnixFd and var argType)
+            {
+                throw new LinuxDbusException($"Unexpected reply argument type {argType} (expected file descriptor)");
+            }
+
+            _inhibitorHandle = LinuxDbusApi.MessageIterGetFileDescriptor(ref replyIter);
+        }
+        finally
+        {
+            if (reply != nint.Zero)
+            {
+                LinuxDbusApi.dbus_message_unref(reply);
+            }
+
+            if (msg != nint.Zero)
+            {
+                LinuxDbusApi.dbus_message_unref(msg);
+            }
+
+            if (conn != nint.Zero)
+            {
+                LinuxDbusApi.dbus_connection_close(conn);
+                LinuxDbusApi.dbus_connection_unref(conn);
+            }
+
+            if (LinuxDbusApi.dbus_error_is_set(in error))
+            {
+                LinuxDbusApi.dbus_error_free(ref error);
+            }
+        }
+    }
+
+    public void UnblockSleep()
+    {
+        _inhibitorHandle?.Close();
+        _inhibitorHandle = null;
+    }
+
+    public void Dispose()
+    {
+        UnblockSleep();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ To install the compiled binary, download the `.dll`, go to your [plugin folder](
 
 ## Known issues and limitations
 
-- Only Jellyfin Server running on Windows is supported. In particular, this plugin will not work on Linux, MacOS, or Jellyfin docker containers (regardless of the host OS).
+- Only Jellyfin Server running on Windows and Linux is supported. In particular, this plugin will not work on MacOS, or Jellyfin docker containers (regardless of the host OS).
+
+    - On Linux, additional setup may be required. Please look at the [Linux-specific documentation](./docs/Linux.md).
+
 - If the server runs Windows and supports Modern Standby (which applies to the vast majority of non-ancient Windows laptops), this plugin temporarily creates a Power Scheme to reliably prevent sleep while streaming. If this power scheme lingers after terminating Jellyfin, it can be deleted manually. See the [Windows-specific documentation](./docs/Windows.md).
 
 Please don't hesistate to report issues if you find any.

--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -4,8 +4,6 @@ The Linux landscape is vast, and supporting every variation isn't feasible. So t
 
 This plugin may need additional tweaking or fail to work at all on non-standard Linux setups like Fedora Silverblue or NixOS.
 
-(While not tested, it may be possible to have this plugin work in a Docker container with a Linux host meeting the other requirements listed above if you install libdbus in the container and forward the host's `/run/dbus/system_bus_socket` into it. [**Warning**: this may allow malicious programs running in the container to exercise greater control over the host.])
-
 To see if the plugin is doing its job, play something in Jellyfin, and run the following in a terminal:
 ```shell
 systemd-inhibit --list | grep "Prevent Sleep Plugin for Jellyfin"
@@ -15,7 +13,7 @@ If the plugin is working, you will see something similar to the following in the
 
 > Prevent Sleep Plugin for Jellyfin 963  jellyfin 34866 jellyfin sleep Serving files/waiting for the configured amount of time for further requests block
 
-If you see no such output, look at Jellyfin's logs containing `Jellyfin.Plugin.PreventSleep` in order to pinpoint the issue. 
+If you see no such output, look at Jellyfin's logs containing `Jellyfin.Plugin.PreventSleep` in order to pinpoint the issue.
 
 ## Allowing non-interactive sleep inhibition
 
@@ -46,3 +44,10 @@ polkit.addRule(function(action, subject) {
 ```shell
 sudo systemctl restart jellyfin
 ```
+
+## Docker support
+
+While not tested, it may be possible to have this plugin work in a Docker container with a Linux host meeting the other requirements listed above if you install libdbus in the container and forward the host's `/run/dbus/system_bus_socket` into it.
+
+> [!WARNING]
+> This may allow malicious programs running in the container to exercise greater control over the host.

--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -1,0 +1,46 @@
+# Linux specifics
+
+The Linux landscape is vast, and supporting every variation isn't feasible. So this plugin has prioritised support for one of the more common combinations: a system running systemd (or a logind implementation, like elogind), with libdbus installed, and Jellyfin installed on the host.
+
+This plugin probably will not work on immutable distributions, like Fedora Silverblue.
+
+(While not tested, it may be possible to have this plugin work in a Docker container with a Linux host meeting the other requirements listed above if you install libdbus in the container and forward the host's `/run/dbus/system_bus_socket` into it. [**Warning**: this may allow malicious programs running in the container to exercise greater control over the host.])
+
+To see if the plugin is doing its job, play something in Jellyfin, and run the following in a terminal:
+```shell
+systemd-inhibit --list | grep "Prevent Sleep Plugin for Jellyfin"
+```
+
+If the plugin is working, you will see something similar to the following in the command's output:
+
+> Prevent Sleep Plugin for Jellyfin 963  jellyfin 34866 jellyfin sleep Serving files/waiting for the configured amount of time for further requests block
+
+## Allowing non-interactive sleep inhibition
+
+> [!NOTE]
+> The Polkit rule provided here assumes Jellyfin is being run by a user called `jellyfin`. The [Debian/Ubuntu](https://github.com/jellyfin/jellyfin-packaging/blob/master/debian/conf/jellyfin.service#L8), [Arch Linux](https://gitlab.archlinux.org/archlinux/packaging/packages/jellyfin-server/-/blob/main/sysusers.conf), [Gentoo](https://codeberg.org/gentoo/gentoo/src/branch/master/www-apps/jellyfin-bin/files/jellyfin.service#L6), and [Fedora](https://github.com/rpmfusion/jellyfin/blob/master/jellyfin.service#L8) Jellyfin packages create a dedicated `jellyfin` user to run Jellyfin as. If the rule here is not suitable for your system, please read [`polkit(8)`](https://www.freedesktop.org/software/polkit/docs/latest/polkit.8.html#polkit-rules-polkit) to adapt it.
+
+If your computer is still suspending while playing something in Jellyfin and you are seeing errors in your Jellyfin log similar to
+
+> System.UnauthorizedAccessException: Preventing sleep requires authentication.
+
+you will need to perform the following to allow the plugin to inhibit sleep without requiring authentication:
+
+1. Run this in a Terminal:
+```shell
+sudo nano /etc/polkit-1/rules.d/10-jellyfin-preventsleep-plugin.rules
+```
+
+2. Paste the following in, save, and quit:
+```js
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.login1.inhibit-block-sleep" && subject.user == "jellyfin") {
+        return polkit.Result.YES;
+    }
+});
+```
+
+3. Restart your Jellyfin server:
+```shell
+sudo systemctl restart jellyfin
+```

--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -2,7 +2,7 @@
 
 The Linux landscape is vast, and supporting every variation isn't feasible. So this plugin has prioritised support for one of the more common combinations: a system running systemd (or a logind implementation, like elogind), with libdbus installed, and Jellyfin installed on the host.
 
-This plugin probably will not work on immutable distributions, like Fedora Silverblue.
+This plugin may need additional tweaking or fail to work at all on non-standard Linux setups like Fedora Silverblue or NixOS.
 
 (While not tested, it may be possible to have this plugin work in a Docker container with a Linux host meeting the other requirements listed above if you install libdbus in the container and forward the host's `/run/dbus/system_bus_socket` into it. [**Warning**: this may allow malicious programs running in the container to exercise greater control over the host.])
 
@@ -14,6 +14,8 @@ systemd-inhibit --list | grep "Prevent Sleep Plugin for Jellyfin"
 If the plugin is working, you will see something similar to the following in the command's output:
 
 > Prevent Sleep Plugin for Jellyfin 963  jellyfin 34866 jellyfin sleep Serving files/waiting for the configured amount of time for further requests block
+
+If you see no such output, look at Jellyfin's logs containing `Jellyfin.Plugin.PreventSleep` in order to pinpoint the issue. 
 
 ## Allowing non-interactive sleep inhibition
 

--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -15,6 +15,9 @@ If the plugin is working, you will see something similar to the following in the
 
 If you see no such output, look at Jellyfin's logs containing `Jellyfin.Plugin.PreventSleep` in order to pinpoint the issue.
 
+> [!NOTE]
+> Sleep may not be reattempted until the entire configured system sleep duration has passed, *starting* from when the Prevent Sleep Plugin has released its sleep inhibitor. To avoid possibly having your computer stay awake for a long while, make sure the *delay before unblocking sleep* Prevent Sleep plugin setting is set to a low value.
+
 ## Allowing non-interactive sleep inhibition
 
 > [!NOTE]


### PR DESCRIPTION
Following your work to make things in this plugin more generic, this adds support for inhibiting sleep on Linux via systemd/logind. 
As there's a thousand-and-one combinations of configuring Linux and running Jellyfin atop it out there, this focuses on one common configuration: systemd (or elogind) in use, libdbus installed (99% likely on a desktop system) and Jellyfin running directly on the host.

Notably, this excludes installs where Jellyfin is installed in a Docker container running on a Linux system. It may be possible to get this plugin working in such a configuration - I theorised a little on it in the notes I've left in [docs/Linux.md](https://github.com/qwerty12/jellyfin-plugin-preventsleep/blob/freedesktop.org/Linux/docs/Linux.md) - but it wasn't something I cared about enough to actually try.

I have tested this PR on two Linux installs successfully: Fedora Linux 44 running GNOME and CachyOS (compatible Arch Linux derivative) running KDE. Both installs were configured to dim the screen, lock the workstation and then go to sleep afterwards. When playing something in Jellyfin with this plugin active, while the first two actions occurred as expected, *the system did not go to sleep*.
The exact same DLL running on my Windows install didn't cause any crashes; preventing sleep still worked.

Notes/observations:

* with CsWin32's inclusion, it's impossible to build this plugin with the .NET 8 SDK - you need at least .NET 9's SDK targeting .NET 8

* I don't plan to add support for desktop environments' specific ways to inhibit sleep because supporting as many as possible just adds technical debt, and the circumstances in which Jellyfin can be started by a user and have the DE-specific methods made available aren't common. Targeting logind is the strongest way to achieve sleep inhibition; it's what the DEs end up ultimately doing anyway

* the current plumbing of this plugin is geared towards Windows, unsurprisingly, where obtaining the "object" to inhibit sleep and then "activating" it are two distinct operations. In Linux, merely obtaining the object activates it. See this [hack](https://github.com/qwerty12/jellyfin-plugin-preventsleep/blob/freedesktop.org/Linux/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs#L122-L127) to prevent repeated attempts to block sleep when the first operation failed (`_powerManagement` is non `null` at this point but `_unblockTimer` is still `null` because of the exception)

* I opted against using a native D-Bus protocol implementation like [Tmds.DBus](https://github.com/tmds/Tmds.DBus), despite its far nicer API and all those nice managed things like automatic memory management, and went for P/Invoking libdbus.so on the host because

    * an extra Tmds.DBus DLL would need to be distributed alongside Jellyfin.Plugin.PreventSleep.dll, even on Windows

        * making Linux-specific builds with both DLLs bundled, and a Windows-specific build with a single DLL, will become a mess. By using libdbus, we can keep everything in one DLL, like we do currently, and target both platforms with it

* in order for logind to grace Jellyfin with an inhibitor file descriptor, it's very likely the user will need to create a file as root permitting the user the jellyfin process is running as to do so

    * because of this I don't think this plugin will work on immutable distributions like Fedora Silverblue

    * I have written quick steps on how to do this in [docs/Linux.md](https://github.com/qwerty12/jellyfin-plugin-preventsleep/blob/freedesktop.org/Linux/docs/Linux.md) but Linux being Linux, I do not make the promise that that specific Polkit rule is one-size-fits-all. If someone's running Linux, I make the assumption that the user will be able to understand the Polkit documentation and come up with something suitable for their system

    * I don't consider it the plugin's responsibility to try and create this file

* with [some small changes](https://consolekit2.github.io/ConsoleKit2/#Manager.Inhibit), this could be re-used almost as-is to implement FreeBSD support

* I tried `idle` for `What` instead of `sleep` and while no authentication was required, it simply didn't work to stop GNOME from automatically suspending

    * Unfortunately, `sleep` inhibitors prevent user-initiated sleep unless you authorise yourself with a password...