### PR TITLE
Add macOS sleep prevention

### DIFF
--- a/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
+++ b/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
@@ -115,7 +115,7 @@ public class EventMonitorEntryPoint(ISessionManager sessionManager, ILoggerFacto
                 _powerManagement.BlockSleep();
                 _unblockTimer = new Timer(UnblockSleepTimerCallback, null, TimerInterval, TimerInterval);
             }
-            catch (Win32Exception e)
+            catch (Exception e) when (e is Win32Exception or MacosIoKitException)
             {
                 _logger.LogError(e, "Failed to block sleep: {Error}", e);
             }
@@ -137,6 +137,11 @@ public class EventMonitorEntryPoint(ISessionManager sessionManager, ILoggerFacto
                 _logger.LogError(e, "Failed to set up power management. Preventing sleep will not work: {Error}", e);
                 return null;
             }
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return new MacosPowerManagement();
         }
 
         _logger.LogError("Platform is not supported: {Platform}", RuntimeInformation.OSDescription);

--- a/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
+++ b/Jellyfin.Plugin.PreventSleep/EventMonitorEntryPoint.cs
@@ -141,7 +141,7 @@ public class EventMonitorEntryPoint(ISessionManager sessionManager, ILoggerFacto
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return new MacosPowerManagement();
+                return new MacosPowerManagement(_loggerFactory);
             }
 
             _logger.LogError("Platform is not supported: {Platform}", RuntimeInformation.OSDescription);

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosCfStringRef.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosCfStringRef.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Jellyfin.Plugin.PreventSleep.Infrastructure;
+
+internal sealed partial class MacosCfStringRef : SafeHandle
+{
+    private const string CoreFoundation =
+        "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+
+    public MacosCfStringRef() : base(IntPtr.Zero, ownsHandle: true)
+    {
+    }
+
+    private MacosCfStringRef(string value) : base(IntPtr.Zero, ownsHandle: true) =>
+        SetHandle(CFStringCreateWithCharacters(nint.Zero, value, value.Length));
+
+    public MacosCfStringRef(string value, int maxLength) : base(IntPtr.Zero, ownsHandle: true)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        SetHandle(CFStringCreateWithCharacters(nint.Zero, value, Math.Min(value.Length, maxLength)));
+    }
+
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public static implicit operator MacosCfStringRef(string value) => new(value);
+
+    protected override bool ReleaseHandle()
+    {
+        CFRelease(handle);
+        return true;
+    }
+
+    [LibraryImport(CoreFoundation)]
+    private static partial nint CFStringCreateWithCharacters(
+        nint alloc,
+        [MarshalAs(UnmanagedType.LPWStr)] string chars,
+        nint numChars);
+
+    [LibraryImport(CoreFoundation)]
+    private static partial void CFRelease(nint cf);
+}

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosCfStringRef.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosCfStringRef.cs
@@ -8,22 +8,19 @@ internal sealed partial class MacosCfStringRef : SafeHandle
     private const string CoreFoundation =
         "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
 
-    public MacosCfStringRef() : base(IntPtr.Zero, ownsHandle: true)
+    internal MacosCfStringRef(string value) : base(IntPtr.Zero, ownsHandle: true)
     {
-    }
+        var ptr = CFStringCreateWithCharacters(nint.Zero, value, value.Length);
+        if (ptr == nint.Zero)
+        {
+            throw new InvalidOperationException(
+                $"Failed to create CFString from \"{value}\".");
+        }
 
-    private MacosCfStringRef(string value) : base(IntPtr.Zero, ownsHandle: true) =>
-        SetHandle(CFStringCreateWithCharacters(nint.Zero, value, value.Length));
-
-    public MacosCfStringRef(string value, int maxLength) : base(IntPtr.Zero, ownsHandle: true)
-    {
-        ArgumentNullException.ThrowIfNull(value);
-        SetHandle(CFStringCreateWithCharacters(nint.Zero, value, Math.Min(value.Length, maxLength)));
+        SetHandle(ptr);
     }
 
     public override bool IsInvalid => handle == IntPtr.Zero;
-
-    public static implicit operator MacosCfStringRef(string value) => new(value);
 
     protected override bool ReleaseHandle()
     {

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosIoKitException.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosIoKitException.cs
@@ -1,0 +1,6 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Jellyfin.Plugin.PreventSleep.Infrastructure;
+
+internal sealed class MacosIoKitException(int ioReturn)
+    : ExternalException($"IOKit call failed (IOReturn = 0x{ioReturn:X8})", ioReturn);

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosIopmAssertion.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosIopmAssertion.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Jellyfin.Plugin.PreventSleep.Infrastructure;
+
+internal sealed partial class MacosIopmAssertion : SafeHandle
+{
+    private const string IoKit = "/System/Library/Frameworks/IOKit.framework/IOKit";
+    private const int KIoReturnSuccess = 0;
+
+    private MacosIopmAssertion(uint assertionId) : base(IntPtr.Zero, ownsHandle: true)
+        => SetHandle((nint)assertionId);
+
+    public override bool IsInvalid => handle == IntPtr.Zero; // 0 = kIOPMNullAssertionID
+
+    protected override bool ReleaseHandle()
+        => IOPMAssertionRelease((uint)(nuint)handle) == KIoReturnSuccess;
+
+    internal static MacosIopmAssertion Create(
+        MacosCfStringRef assertionType,
+        MacosCfStringRef name,
+        MacosCfStringRef details)
+    {
+        var result = IOPMAssertionCreateWithDescription(
+            assertionType,
+            name,
+            details,
+            nint.Zero,
+            nint.Zero,
+            0,
+            nint.Zero,
+            out var assertionId);
+
+        return result == KIoReturnSuccess ? new MacosIopmAssertion(assertionId) : throw new MacosIoKitException(result);
+    }
+
+    [LibraryImport(IoKit)]
+    private static partial int IOPMAssertionCreateWithDescription(
+        MacosCfStringRef assertionType,
+        MacosCfStringRef name,
+        MacosCfStringRef details,
+        nint humanReadableReason,
+        nint localizationBundlePath,
+        double timeout,
+        nint timeoutAction,
+        out uint assertionId);
+
+    [LibraryImport(IoKit)]
+    private static partial int IOPMAssertionRelease(uint assertionId);
+}

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosPowerManagement.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosPowerManagement.cs
@@ -1,0 +1,48 @@
+﻿using Jellyfin.Plugin.PreventSleep.Interface;
+
+namespace Jellyfin.Plugin.PreventSleep.Infrastructure;
+
+internal sealed class MacosPowerManagement : IPowerManagement
+{
+    private readonly MacosCfStringRef _kIopmAssertionTypePreventUserIdleSystemSleep;
+    private readonly MacosCfStringRef _assertionName;
+    private readonly MacosCfStringRef _assertionDetails;
+    private MacosIopmAssertion? _sleepAssertion;
+
+    internal MacosPowerManagement()
+    {
+        _kIopmAssertionTypePreventUserIdleSystemSleep = "PreventUserIdleSystemSleep";
+        /*
+         * According to https://developer.apple.com/library/archive/qa/qa1340/_index.html
+         * and https://github.com/apple-oss-distributions/PowerManagement/blob/main/caffeinate/caffeinate.c#L169
+         * these strings' length are capped to 128 characters.
+         */
+        _assertionName = new MacosCfStringRef("Prevent Sleep Plugin for Jellyfin", 128);
+        _assertionDetails =
+            new MacosCfStringRef("Serving files/waiting for the configured amount of time for further requests", 128);
+    }
+
+    public void BlockSleep()
+    {
+        if (_sleepAssertion is not null)
+        {
+            return;
+        }
+
+        _sleepAssertion = MacosIopmAssertion.Create(_kIopmAssertionTypePreventUserIdleSystemSleep, _assertionName, _assertionDetails);
+    }
+
+    public void UnblockSleep()
+    {
+        _sleepAssertion?.Close();
+        _sleepAssertion = null;
+    }
+
+    public void Dispose()
+    {
+        _sleepAssertion?.Dispose();
+        _assertionDetails.Dispose();
+        _assertionName.Dispose();
+        _kIopmAssertionTypePreventUserIdleSystemSleep.Dispose();
+    }
+}

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosPowerManagement.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosPowerManagement.cs
@@ -1,16 +1,19 @@
 ﻿using Jellyfin.Plugin.PreventSleep.Interface;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.PreventSleep.Infrastructure;
 
 internal sealed class MacosPowerManagement : IPowerManagement
 {
+    private readonly ILogger<MacosPowerManagement> _logger;
     private readonly MacosCfStringRef _kIopmAssertionTypePreventUserIdleSystemSleep;
     private readonly MacosCfStringRef _assertionName;
     private readonly MacosCfStringRef _assertionDetails;
     private MacosIopmAssertion? _sleepAssertion;
 
-    internal MacosPowerManagement()
+    internal MacosPowerManagement(ILoggerFactory loggerFactory)
     {
+        _logger = loggerFactory.CreateLogger<MacosPowerManagement>();
         _kIopmAssertionTypePreventUserIdleSystemSleep = new MacosCfStringRef("PreventUserIdleSystemSleep");
         /*
          * According to https://developer.apple.com/library/archive/qa/qa1340/_index.html
@@ -29,17 +32,22 @@ internal sealed class MacosPowerManagement : IPowerManagement
         }
 
         _sleepAssertion = MacosIopmAssertion.Create(_kIopmAssertionTypePreventUserIdleSystemSleep, _assertionName, _assertionDetails);
+        _logger.LogDebug("IOPMAssertionCreateWithDescription succeeded: sleep blocked");
     }
 
     public void UnblockSleep()
     {
-        _sleepAssertion?.Close();
-        _sleepAssertion = null;
+        if (_sleepAssertion is not null)
+        {
+            _sleepAssertion.Close();
+            _sleepAssertion = null;
+            _logger.LogDebug("Power assertion released: sleep re-enabled");
+        }
     }
 
     public void Dispose()
     {
-        _sleepAssertion?.Dispose();
+        UnblockSleep();
         _assertionDetails.Dispose();
         _assertionName.Dispose();
         _kIopmAssertionTypePreventUserIdleSystemSleep.Dispose();

--- a/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosPowerManagement.cs
+++ b/Jellyfin.Plugin.PreventSleep/Infrastructure/MacosPowerManagement.cs
@@ -11,15 +11,14 @@ internal sealed class MacosPowerManagement : IPowerManagement
 
     internal MacosPowerManagement()
     {
-        _kIopmAssertionTypePreventUserIdleSystemSleep = "PreventUserIdleSystemSleep";
+        _kIopmAssertionTypePreventUserIdleSystemSleep = new MacosCfStringRef("PreventUserIdleSystemSleep");
         /*
          * According to https://developer.apple.com/library/archive/qa/qa1340/_index.html
          * and https://github.com/apple-oss-distributions/PowerManagement/blob/main/caffeinate/caffeinate.c#L169
          * these strings' length are capped to 128 characters.
          */
-        _assertionName = new MacosCfStringRef("Prevent Sleep Plugin for Jellyfin", 128);
-        _assertionDetails =
-            new MacosCfStringRef("Serving files/waiting for the configured amount of time for further requests", 128);
+        _assertionName = new MacosCfStringRef("Prevent Sleep Plugin for Jellyfin");
+        _assertionDetails = new MacosCfStringRef("Serving files/waiting for the configured amount of time for further requests");
     }
 
     public void BlockSleep()


### PR DESCRIPTION
Disclaimer: I don't have a Mac to hand. All testing (in so far as that's applicable) was done in macOS 14 running on VMware.
As such, I can't actually check if sleep was prevented, but I was able to verify that this plugin creates a power assertion to prevent automatic sleep much the same as running the included-with-macOS [`caffeinate -g`](https://ss64.com/mac/caffeinate.html) does. The code here is fundamentally similar to that of "Listing 2  Preventing sleep using I/O Kit in Mac OS X 10.6 Snow Leopard" in the official Apple document [Technical Q&A QA1340](https://developer.apple.com/library/archive/qa/qa1340/_index.html).

The aforementioned `caffeinate` program [is OSS](https://github.com/apple-oss-distributions/PowerManagement/blob/main/caffeinate/caffeinate.c); it was referenced here.

There are [many power assertions available on macOS](https://developer.apple.com/documentation/iokit/iopmlib_h/iopmassertiontypes); following the [advice written here](https://stackoverflow.com/a/66093676) and noticing Safari uses the same [`kIOPMAssertionTypePreventUserIdleSystemSleep`/`PreventUserIdleSystemSleep`](https://developer.apple.com/documentation/iokit/kiopmassertiontypepreventuseridlesystemsleep?language=objc) when playing video in it, I believe I made the right choice. This way, the display is able to go off, the computer lock etc. but not sleep automatically. Manual sleep is still allowed.

Needless to say, this assumes Jellyfin isn't running in Docker. Like Windows, but unlike Linux, macOS doesn't require any weirdness to prevent sleep:

> No special privileges are necessary to make this call - any process may activate a power assertion. 

<details>

<summary>macOS showing the power assertion has been created by the Jellyfin plugin</summary>

```
qqqq@qqqqs-MacBook-Pro ~ % pmset -g assertions
2026-06-08 01:12:02 +0100
Assertion status system-wide:
   BackgroundTask                 0
   ApplePushServiceTask           0
   UserIsActive                   1
   PreventUserIdleDisplaySleep    0
   PreventSystemSleep             0
   ExternalMedia                  0
   PreventUserIdleSystemSleep     1
   NetworkClientActive            0
Listed by owning process:
   pid 581(jellyfin): [0x00000cff00018286] 00:00:09 PreventUserIdleSystemSleep named: "Prevent Sleep Plugin for Jellyfin"
        Details: Serving files/waiting for the configured amount of time for further requests
Kernel Assertions: 0x4=USB
   id=500  level=255 0x4=USB creat=08/06/2026, 00:24 description=com.apple.usb.externaldevice.00700000 owner=VMware Virtual USB Hub
   id=502  level=255 0x4=USB creat=08/06/2026, 00:25 description=com.apple.usb.externaldevice.00500000 owner=VMware Virtual USB Mouse
   id=503  level=255 0x4=USB creat=08/06/2026, 00:26 description=com.apple.usb.externaldevice.00600000 owner=VMware Virtual USB Keyboard
   id=504  level=255 0x4=USB creat=08/06/2026, 00:27 description=com.apple.usb.externaldevice.00800000 owner=VMware Virtual USB Hub
Idle sleep preventers: IODisplayWrangler
```

</details>